### PR TITLE
Feat: introduce a Bitmap type

### DIFF
--- a/firebolt/arrays/base.mojo
+++ b/firebolt/arrays/base.mojo
@@ -1,5 +1,6 @@
-from memory import ArcPointer
 from .primitive import *
+from ..buffers import Buffer, Bitmap
+from sys.info import sizeof
 
 
 trait Array(Movable, Sized):
@@ -11,12 +12,12 @@ trait Array(Movable, Sized):
 struct ArrayData(Movable):
     var dtype: DataType
     var length: Int
-    var bitmap: ArcPointer[Buffer]
+    var bitmap: ArcPointer[Bitmap]
     var buffers: List[ArcPointer[Buffer]]
     var children: List[ArcPointer[ArrayData]]
 
     fn is_valid(self, index: Int) -> Bool:
-        return self.bitmap[].unsafe_get[DType.bool](index)
+        return self.bitmap[].unsafe_get(index)
 
     fn as_primitive[T: DataType](self) raises -> PrimitiveArray[T]:
         return PrimitiveArray[T](self)

--- a/firebolt/arrays/binary.mojo
+++ b/firebolt/arrays/binary.mojo
@@ -6,7 +6,7 @@ from ..dtypes import *
 
 struct StringArray(Array):
     var data: ArrayData
-    var bitmap: ArcPointer[Buffer]
+    var bitmap: ArcPointer[Bitmap]
     var offsets: ArcPointer[Buffer]
     var values: ArcPointer[Buffer]
     var capacity: Int
@@ -24,7 +24,7 @@ struct StringArray(Array):
         self.capacity = data.length
 
     fn __init__(out self, capacity: Int = 0):
-        var bitmap = Buffer.alloc[DType.bool](capacity)
+        var bitmap = Bitmap.alloc(capacity)
         # TODO(kszucs): initial values capacity should be either 0 or some value received from the user
         var values = Buffer.alloc[DType.uint8](capacity)
         var offsets = Buffer.alloc[DType.uint32](capacity + 1)
@@ -56,14 +56,14 @@ struct StringArray(Array):
         return self.data
 
     fn grow(mut self, capacity: Int):
-        self.bitmap[].grow[DType.bool](capacity)
+        self.bitmap[].as_buffer()[].grow[DType.bool](capacity)
         self.offsets[].grow[DType.uint32](capacity + 1)
         self.capacity = capacity
 
     # fn shrink_to_fit(out self):
 
     fn is_valid(self, index: Int) -> Bool:
-        return self.bitmap[].unsafe_get[DType.bool](index)
+        return self.bitmap[].unsafe_get(index)
 
     fn unsafe_append(mut self, value: String):
         # todo(kszucs): use unsafe set
@@ -71,7 +71,7 @@ struct StringArray(Array):
         var last_offset = self.offsets[].unsafe_get[DType.uint32](index)
         var next_offset = last_offset + len(value)
         self.data.length += 1
-        self.bitmap[].unsafe_set[DType.bool](index, True)
+        self.bitmap[].unsafe_set(index, True)
         self.offsets[].unsafe_set[DType.uint32](index + 1, next_offset)
         self.values[].grow[DType.uint8](next_offset)
         var dst_address = self.values[].offset(Int(last_offset))

--- a/firebolt/arrays/primitive.mojo
+++ b/firebolt/arrays/primitive.mojo
@@ -1,5 +1,5 @@
 from memory import ArcPointer
-from ..buffers import Buffer
+from ..buffers import Buffer, Bitmap
 from ..dtypes import *
 
 
@@ -9,7 +9,7 @@ struct PrimitiveArray[T: DataType](Array):
     alias dtype = T
     alias scalar = Scalar[T.native]
     var data: ArrayData
-    var bitmap: ArcPointer[Buffer]
+    var bitmap: ArcPointer[Bitmap]
     var buffer: ArcPointer[Buffer]
     var capacity: Int
 
@@ -27,7 +27,7 @@ struct PrimitiveArray[T: DataType](Array):
 
     fn __init__(out self, capacity: Int = 0):
         self.capacity = capacity
-        self.bitmap = Buffer.alloc[DType.bool](capacity)
+        self.bitmap = Bitmap.alloc(capacity)
         self.buffer = Buffer.alloc[T.native](capacity)
         self.data = ArrayData(
             dtype=T,
@@ -47,7 +47,7 @@ struct PrimitiveArray[T: DataType](Array):
         return self.data
 
     fn grow(mut self, capacity: Int):
-        self.bitmap[].grow[DType.bool](capacity)
+        self.bitmap[].as_buffer()[].grow[DType.bool](capacity)
         self.buffer[].grow[T.native](capacity)
         self.capacity = capacity
 
@@ -57,7 +57,7 @@ struct PrimitiveArray[T: DataType](Array):
 
     @always_inline
     fn is_valid(self, index: Int) -> Bool:
-        return self.bitmap[].unsafe_get[DType.bool](index)
+        return self.bitmap[].unsafe_get(index)
 
     @always_inline
     fn unsafe_get(self, index: Int) -> Self.scalar:
@@ -65,7 +65,7 @@ struct PrimitiveArray[T: DataType](Array):
 
     @always_inline
     fn unsafe_set(mut self, index: Int, value: Self.scalar):
-        self.bitmap[].unsafe_set[DType.bool](index, True)
+        self.bitmap[].unsafe_set(index, True)
         self.buffer[].unsafe_set[T.native](index, value)
 
     @always_inline

--- a/firebolt/arrays/tests/test_base.mojo
+++ b/firebolt/arrays/tests/test_base.mojo
@@ -1,11 +1,12 @@
 from testing import assert_equal
-from firebolt.arrays.base import ChunkedArray, ArrayData, Buffer
+from firebolt.arrays.base import ChunkedArray, ArrayData
+from firebolt.buffers import Buffer, Bitmap
 from firebolt.dtypes import int8
 from memory import ArcPointer
 
 
 def test_chunked_array():
-    var bitmap = ArcPointer[Buffer](Buffer.alloc[DType.uint8](1))
+    var bitmap = ArcPointer(Bitmap.alloc(1))
     var buffers = List[ArcPointer[Buffer]]()
     buffers.append(ArcPointer(Buffer.alloc[DType.uint8](1)))
     var array_data = ArrayData(

--- a/firebolt/buffers.mojo
+++ b/firebolt/buffers.mojo
@@ -1,4 +1,4 @@
-from memory import UnsafePointer, memset_zero, memcpy
+from memory import UnsafePointer, memset_zero, memcpy, ArcPointer
 from sys.info import sizeof
 import math
 
@@ -101,3 +101,97 @@ struct Buffer(Movable):
         else:
             alias output = Scalar[T]
             self.ptr.bitcast[output]()[index] = value
+
+
+struct Bitmap(Writable):
+    """Hold information about the null records in an array.
+
+    This is a specialized Buffer, not sure how to share the code.
+    """
+
+    var ptr: UnsafePointer[UInt8]
+    var size: Int
+    var owns: Bool
+
+    @staticmethod
+    fn alloc[I: Intable](length: I) -> Bitmap:
+        var size = _required_bytes(Int(length), DType.bool)
+        var ptr = UnsafePointer[UInt8, alignment=64].alloc(size)
+        memset_zero(ptr.bitcast[UInt8](), size)
+        return Bitmap(ptr, size)
+
+    fn __init__(
+        out self, ptr: UnsafePointer[UInt8], size: Int, owns: Bool = True
+    ):
+        self.ptr = ptr
+        self.size = size
+        self.owns = owns
+
+    fn __moveinit__(out self, owned existing: Self):
+        self.ptr = existing.ptr
+        self.size = existing.size
+        self.owns = existing.owns
+
+    fn __del__(owned self):
+        if self.owns:
+            self.ptr.free()
+
+    fn write_to[W: Writer](self, mut writer: W):
+        """
+        Formats this buffer to the provided Writer.
+
+        Parameters:
+            W: A type conforming to the Writable trait.
+
+        Args:
+            writer: The object to write to.
+        """
+
+        for i in range(self.length()):
+            var value = self.unsafe_get(i)
+            if value:
+                writer.write("T")
+            else:
+                writer.write("f")
+
+    @always_inline
+    fn as_buffer(ref self) -> UnsafePointer[Buffer]:
+        """Cast as a Buffer."""
+        return UnsafePointer.address_of(self).bitcast[Buffer]()
+
+    @staticmethod
+    fn view[
+        I: Intable, //
+    ](
+        ptr: UnsafePointer[NoneType], length: I, dtype: DType = DType.uint8
+    ) -> Bitmap:
+        var size = _required_bytes(Int(length), dtype)
+        return Bitmap(ptr.bitcast[UInt8](), size, owns=False)
+
+    fn unsafe_get(self, index: Int) -> Bool:
+        return self.as_buffer()[].unsafe_get[DType.bool](index)
+
+    fn unsafe_set(mut self, index: Int, value: Bool) -> None:
+        self.as_buffer()[].unsafe_set[DType.bool](index, True)
+
+    fn length(self) -> Int:
+        return self.as_buffer()[].length[DType.bool]()
+
+    fn extend(
+        mut self,
+        other: Bitmap,
+        start: Int,
+        length: Int,
+    ) -> None:
+        """Extends the bitmap with the other's array's bitmap.
+
+        Args:
+            other: The bitmap to take content from.
+            start: The starting index in the destination array.
+            length: The number of elements to copy from the source array.
+        """
+        var desired_size = _required_bytes(start + length, DType.bool)
+        self.as_buffer()[].grow[DType.bool](desired_size)
+
+        for i in range(length):
+            self.unsafe_set(i + start, other.unsafe_get(i))

--- a/firebolt/c_data.mojo
+++ b/firebolt/c_data.mojo
@@ -204,13 +204,13 @@ struct CArrowArray:
         return ptr.take_pointee()
 
     fn to_array(self, dtype: DataType) raises -> ArrayData:
-        var bitmap: ArcPointer[Buffer]
+        var bitmap: ArcPointer[Bitmap]
         if self.buffers[0]:
-            bitmap = Buffer.view(self.buffers[0], self.length, DType.bool)
+            bitmap = Bitmap.view(self.buffers[0], self.length, DType.bool)
         else:
             # bitmaps are allowed to be nullptrs by the specification, in this
             # case we allocate a new buffer to hold the null bitmap
-            bitmap = Buffer.alloc[DType.uint8](self.length)
+            bitmap = Bitmap.alloc(self.length)
 
         var buffers = List[ArcPointer[Buffer]]()
         if dtype.is_numeric():

--- a/firebolt/tests/test_buffers.mojo
+++ b/firebolt/tests/test_buffers.mojo
@@ -52,12 +52,32 @@ def test_buffer():
 
 
 def test_bitmap():
-    var b = Buffer.alloc[DType.bool](10)
+    var b = Bitmap.alloc(10)
     assert_equal(b.size, 64)
-    assert_equal(b.length[DType.bool](), 64 * 8)
+    assert_equal(b.length(), 64 * 8)
 
+    assert_false(b.unsafe_get(0))
     b.unsafe_set(0, True)
-    assert_true(b.unsafe_get[DType.bool](0))
-    assert_false(b.unsafe_get[DType.bool](1))
+    assert_true(b.unsafe_get(0))
+    assert_false(b.unsafe_get(1))
     b.unsafe_set(1, True)
-    assert_true(b.unsafe_get[DType.bool](1))
+    assert_true(b.unsafe_get(1))
+
+
+def test_expand_bitmap() -> None:
+    var bitmap = Bitmap.alloc(6)
+    bitmap.unsafe_set(0, True)
+    bitmap.unsafe_set(5, True)
+    assert_false(bitmap.unsafe_get(1))
+
+    # Create a new bitmap with 2 bits
+    var new_bitmap = Bitmap.alloc(2)
+    new_bitmap.unsafe_set(0, True)
+
+    # Expand the bitmap
+    bitmap.extend(new_bitmap, 6, 2)
+    assert_true(bitmap.unsafe_get(0))
+    assert_false(bitmap.unsafe_get(1))
+    assert_true(bitmap.unsafe_get(5))
+    assert_true(bitmap.unsafe_get(6))
+    assert_false(bitmap.unsafe_get(10))


### PR DESCRIPTION
Copy some of the functionality of Buffer into a new Bitmap type.

Note that inheritance or other means of sharing code (like Rust's NewType) are not yet supported in Mojo.